### PR TITLE
start dcssd in $HOME/.css if no .css files in current directory

### DIFF
--- a/bin/dcssd
+++ b/bin/dcssd
@@ -11,6 +11,10 @@ if ARGV.include?('-v')
   exit
 end
 
+if Dir.glob('*.css').empty? and not Dir.glob(File.join(ENV['HOME'], ".css/*.css")).empty?
+  Dir.chdir(File.join(ENV['HOME'], ".css"))
+end
+
 require "webrick"
 
 dotcss = Class.new(WEBrick::HTTPServlet::AbstractServlet) do


### PR DESCRIPTION
It looks like Unity/Gnome only sometimes respects the `Path` variable in `.desktop` files, which prompted this.

Changes directory to `$HOME/.css` if there are `.css` files in that directory but not in the current directory.
